### PR TITLE
[FLP-1896] - Ensure when withdrawal reason is updated that an event is sent

### DIFF
--- a/src/AcceptanceTests/Features/ShortCourses/UpdateShortCourse.feature
+++ b/src/AcceptanceTests/Features/ShortCourses/UpdateShortCourse.feature
@@ -6,8 +6,9 @@ Scenario: Update unapproved short course withdrawal date
         | WithdrawalDate | WithdrawalReasonCode |
         | 2025-01-01     | 2                    |
     Then the update short course response includes changes
-        | Change         |
-        | WithdrawalDate |
+        | Change           |
+        | WithdrawalDate   |
+        | WithdrawalReason |
 
 Scenario: Update approved short course withdrawal date
     Given SLD has informed the system that a new short course has been created
@@ -16,8 +17,9 @@ Scenario: Update approved short course withdrawal date
         | WithdrawalDate | WithdrawalReasonCode |
         | 2025-01-01     | 2                    |
     Then the update short course response includes changes
-        | Change         |
-        | WithdrawalDate |
+        | Change           |
+        | WithdrawalDate   |
+        | WithdrawalReason |
     And the correct learning withdrawn event is emitted
 
 Scenario: Update short course completion date

--- a/src/AcceptanceTests/Features/ShortCourses/UpdateShortCourse.feature
+++ b/src/AcceptanceTests/Features/ShortCourses/UpdateShortCourse.feature
@@ -19,7 +19,6 @@ Scenario: Update approved short course withdrawal date
     Then the update short course response includes changes
         | Change           |
         | WithdrawalDate   |
-        | WithdrawalReason |
     And the correct learning withdrawn event is emitted
 
 Scenario: Update short course completion date

--- a/src/AcceptanceTests/StepDefinitions/ShortCourses/ShortCourseStepDefinitions.cs
+++ b/src/AcceptanceTests/StepDefinitions/ShortCourses/ShortCourseStepDefinitions.cs
@@ -43,6 +43,7 @@ public class ShortCourseStepDefinitions
     {
         var request = GetDefaultShortCourse();
         request.OnProgramme.Single().WithdrawalDate = null;
+        request.OnProgramme.Single().WithdrawalReasonCode = null;
         await CallCreateShortCourseEndpoint(request);
     }
 

--- a/src/Domain.Tests/ShortCourseLearning/WhenUpdatingShortCourseWithdrawalDate.cs
+++ b/src/Domain.Tests/ShortCourseLearning/WhenUpdatingShortCourseWithdrawalDate.cs
@@ -15,7 +15,7 @@ namespace SFA.DAS.Learning.Domain.UnitTests.ShortCourseLearning;
 [TestFixture]
 public class WhenUpdatingShortCourseWithdrawalDate
 {
-    private Fixture _fixture;
+    private Fixture _fixture = null!;
 
     [SetUp]
     public void SetUp()
@@ -46,11 +46,44 @@ public class WhenUpdatingShortCourseWithdrawalDate
     }
 
     [Test]
+    public void AndWithdrawalReasonChanged_ThenNewWithdrawalReasonShouldBePickedUpAndEventRaised()
+    {
+        var created = DateTime.UtcNow;
+        var startDate = new DateTime(2024, 1, 1);
+        var withdrawalDate = new DateTime(2024, 6, 1);
+        const short updatedWithdrawalReasonCode = 10;
+        var learning = CreateLearning(isApproved: true, startDate: startDate, withdrawalDate: null);
+        var updateContext = CreateUpdateContext(learning, withdrawalDate, updatedWithdrawalReasonCode);
+
+        var expectedEvent = new LearningWithdrawnEvent
+        {
+            ApprovalsApprenticeshipId = learning.Episodes.Single().ApprovalsApprenticeshipId,
+            Created = created,
+            EmployerAccountId = learning.Episodes.Single().EmployerAccountId,
+            LastDayOfLearning = withdrawalDate,
+            LearningKey = learning.Key,
+            WithdrawalReasonCode = updatedWithdrawalReasonCode
+        };
+
+        learning.Update(updateContext);
+
+        var events = learning.FlushEvents().OfType<LearningWithdrawnEvent>().ToList();
+        events.Should().ContainSingle();
+        var @event = events.Single();
+
+        // Use BeEquivalentTo to compare all properties except Created, which is time-sensitive.
+        // We then check the DateTime separately to ensure it's close to the current time.
+        // A bit messy but provides ability for a proper full object comparison whilst still satisfying the need to check the Created property is close to now.
+        @event.Should().BeEquivalentTo(expectedEvent, options => options.Excluding(x => x.Created));
+        @event.Created.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(2));
+    }
+
+    [Test]
     public void AndWithdrawalDateEqualsStartDate_ThenReasonIsStillWithdrawDuringLearning()
     {
         var startDate = new DateTime(2024, 1, 1);
         var learning = CreateLearning(isApproved: true, startDate: startDate, withdrawalDate: null);
-        var updateContext = CreateUpdateContext(learning, withdrawalDate: startDate);
+        var updateContext = CreateUpdateContext(learning, withdrawalDate: startDate, withdrawalReasonCode: 10);
 
         learning.Update(updateContext);
 
@@ -105,6 +138,7 @@ public class WhenUpdatingShortCourseWithdrawalDate
             LearningType = LearningType.Apprenticeship,
             Episodes = new List<DataAccess.Entities.Learning.ShortCourseEpisode> { episode }
         };
+
 
         return ShortCourseLearningDomainModel.Get(entity);
     }

--- a/src/Domain/Apprenticeship/ShortCourseLearningDomainModel.cs
+++ b/src/Domain/Apprenticeship/ShortCourseLearningDomainModel.cs
@@ -178,15 +178,10 @@ public class ShortCourseLearningDomainModel : LearningDomainModel<ShortCourseLea
         changes = [];
         var changed = false;
 
-        if (episode.WithdrawalDate != prevWithdrawalDate)
+        if (episode.WithdrawalDate != prevWithdrawalDate ||
+            episode.WithdrawalReason != prevWithdrawalReasonCode)
         {
             changes.Add(ShortCourseUpdateChanges.WithdrawalDate);
-            changed = true;
-        }
-
-        if (episode.WithdrawalReason != prevWithdrawalReasonCode)
-        {
-            changes.Add(ShortCourseUpdateChanges.WithdrawalReason);
             changed = true;
         }
 

--- a/src/Domain/Apprenticeship/ShortCourseLearningDomainModel.cs
+++ b/src/Domain/Apprenticeship/ShortCourseLearningDomainModel.cs
@@ -118,6 +118,7 @@ public class ShortCourseLearningDomainModel : LearningDomainModel<ShortCourseLea
         var prevLearnerRef = episode.LearnerRef;
         var prevStartDate = episode.StartDate;
         var prevExpectedEndDate = episode.ExpectedEndDate;
+        var prevWithdrawalReasonCode = episode.WithdrawalReason;
 
         episode.Update(updateContext);
 
@@ -130,11 +131,21 @@ public class ShortCourseLearningDomainModel : LearningDomainModel<ShortCourseLea
         if (episode.CompletionDate != prevCompletionDate)
             changes.Add(ShortCourseUpdateChanges.CompletionDate);
 
-        if (episode.WithdrawalDate != prevWithdrawalDate)
+        // We only want to send one event for a withdrawal so we check if one of the two withdrawal fields has changed and handle it as one event.
+        if (IsWithdrawn(
+                episode, 
+                prevWithdrawalDate, 
+                prevWithdrawalReasonCode,
+                out var withdrawalChanges))
         {
-            changes.Add(ShortCourseUpdateChanges.WithdrawalDate);
+            changes.AddRange(withdrawalChanges);
 
-            if (episode.IsApproved && episode.WithdrawalDate.HasValue)
+            if (episode is
+                {
+                    IsApproved: true,
+                    WithdrawalReason: not null,
+                    WithdrawalDate: not null
+                })
             {
                 AddEvent(new LearningWithdrawnEvent
                 {
@@ -156,6 +167,30 @@ public class ShortCourseLearningDomainModel : LearningDomainModel<ShortCourseLea
 
         if(episode.ForceEarningsSync)
             changes.Add(ShortCourseUpdateChanges.ForceEarningsSync);
+    }
+
+    private static bool IsWithdrawn(
+        ShortCourseEpisodeDomainModel episode, 
+        DateTime? prevWithdrawalDate, 
+        short? prevWithdrawalReasonCode, 
+        out List<ShortCourseUpdateChanges> changes)
+    {
+        changes = [];
+        var changed = false;
+
+        if (episode.WithdrawalDate != prevWithdrawalDate)
+        {
+            changes.Add(ShortCourseUpdateChanges.WithdrawalDate);
+            changed = true;
+        }
+
+        if (episode.WithdrawalReason != prevWithdrawalReasonCode)
+        {
+            changes.Add(ShortCourseUpdateChanges.WithdrawalReason);
+            changed = true;
+        }
+
+        return changed;
     }
 
     public Guid? Remove(long ukprn)

--- a/src/SFA.DAS.Learning.Enums/ShortCourseUpdateChanges.cs
+++ b/src/SFA.DAS.Learning.Enums/ShortCourseUpdateChanges.cs
@@ -12,5 +12,6 @@ public enum ShortCourseUpdateChanges
     Reinstated = 4,
     StartDate = 5,
     ExpectedEndDate = 6,
-    ForceEarningsSync = 7
+    ForceEarningsSync = 7,
+    WithdrawalReason = 8,
 }

--- a/src/SFA.DAS.Learning.Enums/ShortCourseUpdateChanges.cs
+++ b/src/SFA.DAS.Learning.Enums/ShortCourseUpdateChanges.cs
@@ -12,6 +12,5 @@ public enum ShortCourseUpdateChanges
     Reinstated = 4,
     StartDate = 5,
     ExpectedEndDate = 6,
-    ForceEarningsSync = 7,
-    WithdrawalReason = 8,
+    ForceEarningsSync = 7
 }


### PR DESCRIPTION
[FLP-1896]

- Bug ticket is for when the withdrawal reason is updated but not the date i.e. update 1 both were updated, update 2 the reason only was updated, the original code did not send a LearnerWithdrawnEvent 

[FLP-1896]: https://skillsfundingagency.atlassian.net/browse/FLP-1896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ